### PR TITLE
Refactor appointments

### DIFF
--- a/EEMI/EEMI/ApiClient.swift
+++ b/EEMI/EEMI/ApiClient.swift
@@ -20,21 +20,19 @@ enum Endpoints {
     case getAppointments(String, String)
 
     func url() -> URL {
-        var path:String
+        var path: String
         let baseUrl = "http://emmiapi.azurewebsites.net/api"
 
         switch self {
         case let .getTokens(username, password):
             path = "/Token?username=\(username)&password=\(password)".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
         case let .getAppointments(startDate, endDate):
-            path = "/Agenda/GetByDate/\(startDate)/\(endDate)".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
+            path = "/Agenda/GetByDate/\(startDate)/\(endDate)"
         }
 
         return URL(string: baseUrl + path)!
     }
 }
-
-
 
 class ApiClient {
 
@@ -47,11 +45,10 @@ class ApiClient {
         let loginUrl = Endpoints.getTokens(username, password).url()
         Alamofire.request(loginUrl).responseJSON { response in
             switch response.result {
-            case .success:
-                let data = response.data
-                let json = try? JSON(data: data!)
-                let token = json?["access_token"].stringValue
-                completion(.success(token!))
+            case .success(let value):
+                let json = JSON(value)
+                let token = json["access_token"].stringValue
+                completion(.success(token))
             case .failure(let error):
                 completion(.error(error.localizedDescription))
             }
@@ -75,7 +72,6 @@ class ApiClient {
                 var appointments = [Appointment]()
                 let json = JSON(value)
                 
-
                 guard let jsonAppointments = json.array else {
                     return completion(.success(appointments))
                 }

--- a/EEMI/EEMI/ApiClient.swift
+++ b/EEMI/EEMI/ApiClient.swift
@@ -9,7 +9,6 @@
 import Foundation
 import Alamofire
 import SwiftyJSON
-import Cache
 
 enum Result<T> {
     case success(T)

--- a/EEMI/EEMI/Appointment.swift
+++ b/EEMI/EEMI/Appointment.swift
@@ -14,11 +14,26 @@ class Appointment {
     var patientLastName: String?
     var reason: String?
     var comments: String?
-    
+    var appointmentTime: Date?
+
     init(json: JSON) {
         self.patientName = json["patientName"].string
         self.patientLastName = json["patientLastName"].string
         self.comments = json["comments"].string
         self.reason = json["reason"].string
+        self.appointmentTime = join(json: json)
+    }
+
+    private
+    func join (json: JSON) -> Date {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+
+        let date = json["dateAppointment"].string ?? "0000-00-00"
+        let time = json["timeAppointment"].string ?? "00:00:00"
+        var splitDate = date.split(separator: "T")
+
+        let joinedDates = splitDate[0] + "'T'" + time
+        return dateFormatter.date(from: joinedDates)!
     }
 }

--- a/EEMI/EEMI/Appointment.swift
+++ b/EEMI/EEMI/Appointment.swift
@@ -24,16 +24,17 @@ class Appointment {
         self.appointmentTime = join(json: json)
     }
 
-    private
-    func join (json: JSON) -> Date {
+    private func join (json: JSON) -> Date? {
         let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
-
-        let date = json["dateAppointment"].string ?? "0000-00-00"
-        let time = json["timeAppointment"].string ?? "00:00:00"
-        var splitDate = date.split(separator: "T")
-
-        let joinedDates = splitDate[0] + "'T'" + time
-        return dateFormatter.date(from: joinedDates)!
+        dateFormatter.dateFormat = "MM/dd/yyyyHH:mm:ss"
+        
+        var dateAppointment = json["dateAppointment"].string ?? ""
+        let timeAppointment = json["timeAppointment"].string ?? ""
+        
+        let split = dateAppointment.split(separator: " ")
+        dateAppointment = String(split.first ?? "")
+        let fullDateString = dateAppointment + timeAppointment
+        
+        return dateFormatter.date(from: fullDateString)
     }
 }


### PR DESCRIPTION
#### DESCRIPCION
* Refactor para juntar `dateAppointment` and `timeAppointment` en una sola variable de `Date`.
----

#### CRITERIOS DE ACEPTACION
* Se regresa un solo objeto date con descripción: `yyyy-MM-dd'T'HH:mm:ss`.

---

#### DETALLES IMPORTANTES NO-FUNCIONALES
* Debe suceder en la inicialización de cada cita.
-------

#### PRIORIDAD
* Alta
----

#### To Do
 - [x] Se genera un solo objeto tipo `Date` que se mandara al controlador.